### PR TITLE
Install  python crmod lib

### DIFF
--- a/1.13/Dockerfile
+++ b/1.13/Dockerfile
@@ -25,10 +25,15 @@ RUN apt-get -y update \
     libtbb-dev \
     libluabind-dev \
     pkg-config \
+    gcc \
+    python-dev \
+    python-setuptools \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && rm -rf /tmp/* /var/tmp/*
-
+#Install CRC32C and Installing crcmod
+RUN easy_install -U pip
+RUN pip install -U crcmod
 # Build osrm-backend
 RUN mkdir /osrm-src \
  && cd /osrm-src \


### PR DESCRIPTION
FRom osrm-car (stable) logs
 ==> NOTE: You are downloading one or more large file(s), which would 
run significantly faster if you enabled sliced object downloads. This
feature is enabled by default but requires that compiled crcmod be installed (see "gsutil help crcmod").